### PR TITLE
Chunk improvements

### DIFF
--- a/t.py
+++ b/t.py
@@ -81,12 +81,9 @@ def test_tiff_tile(benchmark, method):
         with tifffile.TiffFile(opened_file) as tif:
             fh = tif.filehandle
             for page in tif.pages:
-                for index, (offset, bytecount) in enumerate(
-                    zip(page.dataoffsets, page.databytecounts)
-                ):
-                    fh.seek(offset)
-                    fh.read(bytecount)
-                    return
+                fh.seek(page.dataoffsets[0])
+                fh.read(page.databytecounts[0])
+                return
 
     benchmark(method, "retina_large.ome.tiff", loader)
 

--- a/t.py
+++ b/t.py
@@ -96,7 +96,8 @@ def test_hdf5_chunk(benchmark, method):
     def loader(opened_file):
         with h5py.File(opened_file) as f:
             data = f["DataSet"]["ResolutionLevel 0"]["TimePoint 0"]["Channel 0"]["Data"]
-            len(data[0:16, 0:256, 0:256])  # FIXME - not first chunk
+            chunks = data.chunks
+            len(data[0:chunks[0]-1, 0:chunks[1]-1, 0:chunks[2]-1])
 
     benchmark(method, "retina_large.ims", loader)
 


### PR DESCRIPTION
Make a few adjustments for loading chunks for HDF/TIFF

- uses the built-in `data.chunks` for guessing the internal chunk size
- only loads the first offset of each TIFF IFD. If the files are writing in tiles, this should load the first tile.

Note all these tests assume the chunk sizes are equivalent between the formats. I used the following sample files](https://github.com/ome/ngff-latency-benchmark/files/5829792/Sample.zip) for testing with the snippet below


```python
import tifffile
import h5py
import time

filename = 'data_3D_uncompressed'

t = time.process_time()
print("HDF")
with h5py.File(filename + '.ims') as f:
    data = f["DataSet"]["ResolutionLevel 0"]["TimePoint 0"]["Channel 0"]["Data"]
    chunks = data.chunks
    len(data[0:chunks[0]-1, 0:chunks[1]-1, 0:chunks[2]-1])
print(time.process_time() - t)

print("TIFF")
t = time.process_time()
with tifffile.TiffFile(filename + '.tiff') as tif:
    fh = tif.filehandle
    for page in tif.pages[0:chunks[0]-1]:
        assert page.databytecounts[0] == chunks[1] * chunks[2]
        fh.seek(page.dataoffsets[0])
        fh.read(page.databytecounts[0])

print(time.process_time() - t)
```

which gave me the following local metrics

```
sbesson@ls30630:benchmark $ venv/bin/python test.py 
IMS
0.00988599999999995
TIFF
0.057335000000000025
```

Also note the `test_tiff_tile` currently loops over all IFDs (Z-stacks) while the example above only goes through the same number of stacks as the chunk in Z defined in IMS.

If we progress with this benchmark, my might need to define fixtures including both the sample file basename as well as the expected chunk/tile sizes so that we compare the same reads.