### PR TITLE
Repeat tests and plot 'mean' points from each

### DIFF
--- a/.env
+++ b/.env
@@ -10,3 +10,4 @@ ZC=1
 ROOT=/uod/idr-scratch/ngff-latency-benchmark
 DIR=${ROOT}/${XY}-Z-${Z}-T-${T}-C-${C}-XYC-${XC}-ZC-${ZC}
 BASE=IMS_XY-${XY}-Z-${Z}-T-${T}-C-${C}-XYC-${XC}-ZC-${ZC}
+TEST_REPEATS=3

--- a/.env
+++ b/.env
@@ -1,13 +1,13 @@
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 HOST=nginx
-XY=5536
+XY=65536
 Z=1
-C=5
+C=32
 T=1
 XC=1024
 ZC=1
-ROOT=/Users/wmoore/Desktop/NGFF/ngff-latency-benchmark
+ROOT=/uod/idr-scratch/ngff-latency-benchmark
 DIR=${ROOT}/${XY}-Z-${Z}-T-${T}-C-${C}-XYC-${XC}-ZC-${ZC}
 BASE=IMS_XY-${XY}-Z-${Z}-T-${T}-C-${C}-XYC-${XC}-ZC-${ZC}
 TEST_REPEATS=1

--- a/.env
+++ b/.env
@@ -1,13 +1,13 @@
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
 HOST=nginx
-XY=65536
+XY=5536
 Z=1
-C=32
+C=5
 T=1
 XC=1024
 ZC=1
-ROOT=/uod/idr-scratch/ngff-latency-benchmark
+ROOT=/Users/wmoore/Desktop/NGFF/ngff-latency-benchmark
 DIR=${ROOT}/${XY}-Z-${Z}-T-${T}-C-${C}-XYC-${XC}-ZC-${ZC}
 BASE=IMS_XY-${XY}-Z-${Z}-T-${T}-C-${C}-XYC-${XC}-ZC-${ZC}
-TEST_REPEATS=3
+TEST_REPEATS=1

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you choose to use `retina_large`, you will also need to adjust the parameters
 
 ## Then, start S3 and upload the data
 
-Start the various Docker containers.
+Start the various Docker containers in the background ("detached" mode):
 ```
 docker-compose up -d
 ```

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 DIR=${DIR:-./data}
-export BENCHMARK_DATA=${DIR}/benchmark_data.json
+export BENCHMARK_DATA=${DIR}
 export BENCHMARK_PLOT=${DIR}/benchmark_plot.png
 
 set -e
@@ -9,5 +9,10 @@ set -u
 set -x
 
 cd /benchmark  # TODO: should work without docker
-pytest benchmark.py "$@" --benchmark-json=${BENCHMARK_DATA}
+
+for i in 0{..${TEST_REPEATS}}
+do
+    pytest benchmark.py "$@" --benchmark-json=${BENCHMARK_DATA}/${i}_benchmark_data.json
+done
+
 python plot_results.py

--- a/benchmark/benchmark.sh
+++ b/benchmark/benchmark.sh
@@ -10,7 +10,7 @@ set -x
 
 cd /benchmark  # TODO: should work without docker
 
-for i in 0{..${TEST_REPEATS}}
+for (( i=0; i<$TEST_REPEATS; i++ ))
 do
     pytest benchmark.py "$@" --benchmark-json=${BENCHMARK_DATA}/${i}_benchmark_data.json
 done

--- a/benchmark/plot_results.py
+++ b/benchmark/plot_results.py
@@ -16,9 +16,14 @@ print('base_path', json_path)
 
 named_data = defaultdict(list)
 
+
+test_repeats = int(os.getenv('TEST_REPEATS'))
+json_files = ["%s_benchmark_data.json" % r for r in range(test_repeats)]
+print('json_files', json_files)
+
 for root, dirs, files in os.walk(json_path):
     for file_name in files:
-        if file_name.endswith("_benchmark_data.json"):
+        if file_name in json_files:
             path = os.path.join(root, file_name)
             print('json path', path)
             with open(path) as json_file:
@@ -26,7 +31,12 @@ for root, dirs, files in os.walk(json_path):
 
                 for bm in benchmarks:
                     label = bm['name'].replace('test_', '')
-                    named_data[label].append(bm['stats']['mean'])
+                    if test_repeats == 1:
+                        # Ran tests once: plot every data point
+                        named_data[label] = bm['stats']['data']
+                    else:
+                        # Repeats: take mean value from each
+                        named_data[label].append(bm['stats']['mean'])
 
 
 # print(named_data.keys())
@@ -62,7 +72,7 @@ def get_color(label):
 colors = [get_color(label) for label in labels]
 
 fig1, ax1 = plt.subplots(figsize=(10, 5), dpi=100)
-ax1.set_title(f'ngff benchmark ({xy}x{xy})')
+ax1.set_title(f'ngff benchmark ({xy}x{xy}) n={test_repeats}')
 boxplot = ax1.boxplot(
     data,
     labels=labels,

--- a/benchmark/plot_results.py
+++ b/benchmark/plot_results.py
@@ -3,22 +3,31 @@ import json
 import matplotlib.pyplot as plt
 import numpy as np
 import os
+from collections import defaultdict
 
-json_path = os.environ.get("BENCHMARK_DATA", "benchmark_data.json")
+json_path = os.environ.get("BENCHMARK_DATA", "benchmark_data")
 plot_path = os.environ.get("BENCHMARK_PLOT", "benchmark_plot.png")
 
 xy = os.environ.get("XY", "unknown")
 
 # s3+hdf5, s3+tiff, s3+zarr, remote+hdf5, remote+… so I’d color by tiff/hdf5/zarr
 
-named_data = {}
+print('base_path', json_path)
 
-with open(json_path) as json_file:
-    benchmarks = json.load(json_file)['benchmarks']
+named_data = defaultdict(list)
 
-    for bm in benchmarks:
-        label = bm['name'].replace('test_', '')
-        named_data[label] = bm['stats']['data']
+for root, dirs, files in os.walk(json_path):
+    for file_name in files:
+        if file_name.endswith("_benchmark_data.json"):
+            path = os.path.join(root, file_name)
+            print('json path', path)
+            with open(path) as json_file:
+                benchmarks = json.load(json_file)['benchmarks']
+
+                for bm in benchmarks:
+                    label = bm['name'].replace('test_', '')
+                    named_data[label].append(bm['stats']['mean'])
+
 
 # print(named_data.keys())
 # ['1_byte_overhead[local]', '1_byte_overhead[http]', '1_byte_overhead[boto3]', '1_byte_overhead[s3]',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - BASE
       - DIR
       - HOST
+      - TEST_REPEATS
 
 # from:   https://docs.min.io/docs/deploy-minio-on-docker-compose.html
 


### PR DESCRIPTION
Adds `TEST_REPEATS` (in `.env`) default value is 1.
When increased, tests are run multiple times and we plot the `mean` time from each.
When `TEST_REPEATS=1` we stick with current behaviour of plotting all data points for the test.