### PR TITLE
Nested storage

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -9,4 +9,7 @@ COPY benchmark.sh /benchmark/benchmark.sh
 COPY benchmark.py /benchmark/benchmark.py
 COPY plot_results.py /benchmarks/plot_results.py
 
+# see https://github.com/zarr-developers/zarr-python/pull/699
+RUN conda run -n benchmark pip install git+https://github.com/joshmoore/zarr-python@key-sep#egg=zarr
+
 ENTRYPOINT ["conda", "run", "--no-capture-output", "-n", "benchmark", "bash", "/benchmark/benchmark.sh"]

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -73,7 +73,11 @@ def test_zarr_chunk(benchmark, method):
     class ZarrFixture(Fixture):
 
         def setup(self):
-            self.group = zarr.open_group(filename, storage_options=fs.storage_options)
+            store = zarr.storage.FSStore(
+                filename,
+                key_separator="/",
+                **fs.storage_options)
+            self.group = zarr.group(store=store)
 
         def run(self):
             data = self.group["0"]


### PR DESCRIPTION
As @will-moore also realized in gh-13, the speed of the zarr loading comes from the fact that without the `key_separator='/'` setting, Zarr is assuming all chunks are missing and returning the `fill_value` from memory (very quickly).

This relies on: https://github.com/zarr-developers/zarr-python/pull/699