### PR TITLE
Fix mybinder badge branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![DOI](https://zenodo.org/badge/329595844.svg)](https://zenodo.org/badge/latestdoi/329595844)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ome/ngff-latency-benchmark/master?filepath=notebooks)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ome/ngff-latency-benchmark/main?filepath=notebooks)
 [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ome/ngff-latency-benchmark/)
 
 # OME-NGFF: latency benchmark


### PR DESCRIPTION
Should be `main` instead of `master`. FYI `HEAD` should also work if you want it to automagically use the default branch in other repos.