### PR TITLE
Broken link that did not allow the benchmarks to generate

### DIFF
--- a/generate/imarisWriter-Setup.sh
+++ b/generate/imarisWriter-Setup.sh
@@ -20,7 +20,7 @@ cp -r build/_CPack_Packages/Linux/TGZ/HDF5-1.12.0-Linux/HDF_Group/HDF5/1.12.0/in
 cd ..
 
 #zlib
-wget -N -O zlib-1.2.12.tar.gz https://www.zlib.net/zlib-1.2.12.tar.gz
+wget -N -O zlib-1.2.12.tar.gz https://www.zlib.net/fossils/zlib-1.2.12.tar.gz
 tar -xzf zlib-1.2.12.tar.gz
 cd zlib-1.2.12/
 ./configure --prefix=./zlibInstall


### PR DESCRIPTION
Error: 
![image](https://github.com/ome/bioimage-latency-benchmark/assets/79276285/663b8df3-ff05-439d-be1d-7a4863e8eb5f)

The problem was that the url was updated, so a 404 error was returned. This forbade the execution of the ./generate.sh file correctly.